### PR TITLE
Fix auto PR workflow branch name parsing

### DIFF
--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          branch_name="${GITHUB_REF##*/}"
+          branch_name="${GITHUB_REF#refs/heads/}"
           base_branch="main"
 
           echo "Creating PR from $branch_name to $base_branch"


### PR DESCRIPTION
## Summary
- ensure the auto PR workflow keeps the full branch name when deriving the head ref

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebcb5eec48832691a9451c2f438498